### PR TITLE
Use Travis CI testing to run flake8 on each PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+install:
+    - pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
> # stop the build if there are Python syntax errors or undefined names
>- flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
Those tests currently succeed and this change will prevent future PRs from changing that.

Add free automated flake8 testing of pull requests
The owner of the this repo would need to go to https://travis-ci.org/IBM and flip the repository switch __on__ to enable free automated flake8 testing of each pull request.