### PR TITLE
change API version date

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -72,7 +72,7 @@ stages:
       resp=$( curl --user $wcuser:$wcpass \
                  -H "Content-Type: application/json" \
                  -X POST -d @workspace.json \
-                 $wcurl/v1/workspaces?version=2017-04-21 )
+                 $wcurl/v1/workspaces?version=2017-05-26 )
       echo $resp | json
       WORKSPACE_ID=$( echo $resp | json workspace_id )
 


### PR DESCRIPTION
the latest API version is 2017-05-26 -- i'm testing out a theory that without this change the "jump to" links in a conversation dialog are not uploaded.