### PR TITLE
Updating to make the pipeline integration required

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -4,6 +4,8 @@ messages:
   $i18n: locales.yml
 template:
   name: "Chatbot Asset Deployment"
+  required:
+    - load-bot-assets
 toolchain:
   name: 'chatbot-deploy-{{chatbotName}}-{{timestamp}}'
 services:


### PR DESCRIPTION
User should enter the API key to populate the region, org and space. The fields inside the pipeline integrations will be marked as required only if the pipeline integration is marked as required inside the template